### PR TITLE
Set Port to 443

### DIFF
--- a/src/Nancy.Linker/EnsureHttpsFilter.cs
+++ b/src/Nancy.Linker/EnsureHttpsFilter.cs
@@ -18,6 +18,7 @@
 
       UriBuilder builder = new UriBuilder(uri);
       builder.Scheme = "https";
+      builder.Port = 443;
       return builder.Uri;
     }
   }


### PR DESCRIPTION
If the incoming request is on port 80, changing the scheme to https results in the Uri being https://xxx:80/path